### PR TITLE
javadoc api framework and make receivers return POJOs

### DIFF
--- a/app/src/main/java/edu/gatech/buzzmovieselector/biz/api/ApiCallback.java
+++ b/app/src/main/java/edu/gatech/buzzmovieselector/biz/api/ApiCallback.java
@@ -4,5 +4,9 @@ package edu.gatech.buzzmovieselector.biz.api;
  * Async callback for ApiReceiver
  */
 public interface ApiCallback<T> {
+    /**
+     * onReceive is executed as the callback is called
+     * @param receiver ApiReceiver object executing the callback
+     */
     public void onReceive(ApiReceiver<T> receiver);
 }

--- a/app/src/main/java/edu/gatech/buzzmovieselector/biz/api/ApiCallback.java
+++ b/app/src/main/java/edu/gatech/buzzmovieselector/biz/api/ApiCallback.java
@@ -3,10 +3,10 @@ package edu.gatech.buzzmovieselector.biz.api;
 /**
  * Async callback for ApiReceiver
  */
-public interface ApiCallback<T> {
+public interface ApiCallback<T extends ApiReceiver> {
     /**
      * onReceive is executed as the callback is called
      * @param receiver ApiReceiver object executing the callback
      */
-    public void onReceive(ApiReceiver<T> receiver);
+    public void onReceive(T receiver);
 }

--- a/app/src/main/java/edu/gatech/buzzmovieselector/biz/api/ApiReceiver.java
+++ b/app/src/main/java/edu/gatech/buzzmovieselector/biz/api/ApiReceiver.java
@@ -27,7 +27,7 @@ enum ApiResult {
 /**
  * Holds the response of an ApiCommand
  */
-public class ApiReceiver<T, V> {
+abstract public class ApiReceiver<T, V> {
 
     private class AsyncFutureTask extends AsyncTask<RequestFuture, Integer, Object> {
         @Override
@@ -125,7 +125,5 @@ public class ApiReceiver<T, V> {
      * Gives the response converted to an Entity
      * @return converted entity object
      */
-    public V getEntity() {
-        return (V) getResponse();
-    }
+    abstract public V getEntity();
 }

--- a/app/src/main/java/edu/gatech/buzzmovieselector/biz/api/ApiReceiver.java
+++ b/app/src/main/java/edu/gatech/buzzmovieselector/biz/api/ApiReceiver.java
@@ -27,7 +27,7 @@ enum ApiResult {
 /**
  * Holds the response of an ApiCommand
  */
-public class ApiReceiver<T> {
+public class ApiReceiver<T, V> {
 
     private class AsyncFutureTask extends AsyncTask<RequestFuture, Integer, Object> {
         @Override
@@ -119,5 +119,13 @@ public class ApiReceiver<T> {
      */
     public T getResponse() {
         return (T) responseData;
+    }
+
+    /**
+     * Gives the response converted to an Entity
+     * @return converted entity object
+     */
+    public V getEntity() {
+        return (V) getResponse();
     }
 }

--- a/app/src/main/java/edu/gatech/buzzmovieselector/biz/api/impl/rt/command/RTCommandFactory.java
+++ b/app/src/main/java/edu/gatech/buzzmovieselector/biz/api/impl/rt/command/RTCommandFactory.java
@@ -12,14 +12,27 @@ public class RTCommandFactory {
     private static ApiCommand recentDVDsCommand = new RTRecentDVDs();
     private static ApiCommand recentMoviesCommand = new RTRecentMovies();
 
+    /**
+     * Produces the ApiCommand for recent DVDs
+     * @return instance of RTRecentDVDs
+     */
     public static ApiCommand getRecentDVDsCommand() {
         return recentDVDsCommand;
     }
 
+    /**
+     * Produces the ApiCommand for searching movies
+     * @param search
+     * @return instance of RTMovieSearch
+     */
     public static ApiCommand getMovieSearchCommand(String search) {
         return new RTMovieSearch(search);
     }
 
+    /**
+     * Produces the ApiCommand for recent Movies
+     * @return instance of RTRecentMovies
+     */
     public static ApiCommand getRecentMoviesCommand() {
         return recentMoviesCommand;
     }

--- a/app/src/main/java/edu/gatech/buzzmovieselector/biz/api/impl/rt/command/RTMovieSearch.java
+++ b/app/src/main/java/edu/gatech/buzzmovieselector/biz/api/impl/rt/command/RTMovieSearch.java
@@ -2,10 +2,9 @@ package edu.gatech.buzzmovieselector.biz.api.impl.rt.command;
 
 import edu.gatech.buzzmovieselector.biz.api.ApiCallback;
 import edu.gatech.buzzmovieselector.biz.api.ApiCommand;
-import edu.gatech.buzzmovieselector.biz.api.ApiReceiver;
 import edu.gatech.buzzmovieselector.biz.api.impl.rt.RTInvoker;
+import edu.gatech.buzzmovieselector.biz.api.impl.rt.receiver.RTMovieListReceiver;
 import edu.gatech.buzzmovieselector.service.ApiNetwork;
-import org.json.JSONObject;
 
 import java.net.URLEncoder;
 
@@ -20,7 +19,9 @@ public class RTMovieSearch implements ApiCommand {
         String query = URLEncoder.encode(search);
         url = "http://api.rottentomatoes.com/api/public/v1.0/movies.json?q=" + query + "&page_limit=10&apikey=" + RTInvoker.API_KEY;
     }
-    public ApiReceiver<JSONObject> execute(ApiCallback callback) {
-        return ApiNetwork.getInstance().apiJSON(url, callback);
+
+    @Override
+    public RTMovieListReceiver execute(ApiCallback callback) {
+        return new RTMovieListReceiver(ApiNetwork.getInstance().apiJSON(url), callback);
     }
 }

--- a/app/src/main/java/edu/gatech/buzzmovieselector/biz/api/impl/rt/command/RTRecentDVDs.java
+++ b/app/src/main/java/edu/gatech/buzzmovieselector/biz/api/impl/rt/command/RTRecentDVDs.java
@@ -3,6 +3,7 @@ package edu.gatech.buzzmovieselector.biz.api.impl.rt.command;
 import edu.gatech.buzzmovieselector.biz.api.ApiCallback;
 import edu.gatech.buzzmovieselector.biz.api.ApiCommand;
 import edu.gatech.buzzmovieselector.biz.api.ApiReceiver;
+import edu.gatech.buzzmovieselector.biz.api.impl.rt.receiver.RTMovieListReceiver;
 import edu.gatech.buzzmovieselector.service.ApiNetwork;
 import edu.gatech.buzzmovieselector.biz.api.impl.rt.RTInvoker;
 import org.json.JSONObject;
@@ -14,7 +15,7 @@ public class RTRecentDVDs implements ApiCommand {
     private final String url = "http://api.rottentomatoes.com/api/public/v1.0/lists/dvds/new_releases.json?page_limit=10&apikey=" + RTInvoker.API_KEY;
 
     @Override
-    public ApiReceiver<JSONObject> execute(ApiCallback callback) {
-        return ApiNetwork.getInstance().apiJSON(url, callback);
+    public RTMovieListReceiver execute(ApiCallback callback) {
+        return new RTMovieListReceiver(ApiNetwork.getInstance().apiJSON(url), callback);
     }
 }

--- a/app/src/main/java/edu/gatech/buzzmovieselector/biz/api/impl/rt/command/RTRecentMovies.java
+++ b/app/src/main/java/edu/gatech/buzzmovieselector/biz/api/impl/rt/command/RTRecentMovies.java
@@ -4,6 +4,7 @@ import edu.gatech.buzzmovieselector.biz.api.ApiCallback;
 import edu.gatech.buzzmovieselector.biz.api.ApiCommand;
 import edu.gatech.buzzmovieselector.biz.api.ApiReceiver;
 import edu.gatech.buzzmovieselector.biz.api.impl.rt.RTInvoker;
+import edu.gatech.buzzmovieselector.biz.api.impl.rt.receiver.RTMovieListReceiver;
 import edu.gatech.buzzmovieselector.service.ApiNetwork;
 import org.json.JSONObject;
 
@@ -15,7 +16,7 @@ public class RTRecentMovies implements ApiCommand {
     private final String url = "http://api.rottentomatoes.com/api/public/v1.0/lists/movies/in_theaters.json?page_limit=10&apikey=" + RTInvoker.API_KEY;
 
     @Override
-    public ApiReceiver<JSONObject> execute(ApiCallback callback) {
-        return ApiNetwork.getInstance().apiJSON(url, callback);
+    public RTMovieListReceiver execute(ApiCallback callback) {
+        return new RTMovieListReceiver(ApiNetwork.getInstance().apiJSON(url), callback);
     }
 }

--- a/app/src/main/java/edu/gatech/buzzmovieselector/biz/api/impl/rt/receiver/RTMovieListReceiver.java
+++ b/app/src/main/java/edu/gatech/buzzmovieselector/biz/api/impl/rt/receiver/RTMovieListReceiver.java
@@ -1,0 +1,41 @@
+package edu.gatech.buzzmovieselector.biz.api.impl.rt.receiver;
+
+import com.android.volley.toolbox.RequestFuture;
+import edu.gatech.buzzmovieselector.biz.api.ApiCallback;
+import edu.gatech.buzzmovieselector.biz.api.ApiReceiver;
+import edu.gatech.buzzmovieselector.entity.Movie;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+
+/**
+ * Receives json objects from ApiCalls and makes them into Movie objects
+ */
+public class RTMovieListReceiver extends ApiReceiver<JSONObject, Movie[]> {
+
+    public RTMovieListReceiver(RequestFuture requestFuture, ApiCallback responseCallback) {
+        super(requestFuture, responseCallback);
+    }
+
+    @Override
+    public Movie[] getEntity() {
+        ArrayList<Movie> parsedMovies = new ArrayList<>();
+        JSONObject moviesList = getResponse();
+        try {
+            JSONArray movieList = moviesList.getJSONArray("movies");
+            for (int i = 0; i < movieList.length(); i++) {
+                JSONObject movieJ = movieList.getJSONObject(i);
+                double rating = (double) movieJ.getJSONObject("ratings").getInt("audience_score") / 100.;
+                Movie movie = new Movie(movieJ.getString("title"), movieJ.getInt("year"), rating);
+                parsedMovies.add(movie);
+            }
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+        Movie[] movieArray = new Movie[parsedMovies.size()];
+        movieArray = (Movie[]) parsedMovies.toArray(movieArray);
+        return movieArray;
+    }
+}

--- a/app/src/main/java/edu/gatech/buzzmovieselector/controller/BMSActivity.java
+++ b/app/src/main/java/edu/gatech/buzzmovieselector/controller/BMSActivity.java
@@ -23,6 +23,8 @@ import edu.gatech.buzzmovieselector.biz.api.ApiCallback;
 import edu.gatech.buzzmovieselector.biz.api.ApiReceiver;
 import edu.gatech.buzzmovieselector.biz.api.impl.rt.RTInvoker;
 import edu.gatech.buzzmovieselector.biz.api.impl.rt.command.RTCommandFactory;
+import edu.gatech.buzzmovieselector.biz.api.impl.rt.receiver.RTMovieListReceiver;
+import edu.gatech.buzzmovieselector.entity.Movie;
 import edu.gatech.buzzmovieselector.service.SessionState;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -76,19 +78,11 @@ public class BMSActivity extends AppCompatActivity
         ListView recentDVDs = (ListView) findViewById(R.id.recentDVDsList);
         recentDVDs.setAdapter(listAdapter);
         RTInvoker rti = new RTInvoker();
-        rti.executeCall(new ApiCall(RTCommandFactory.getRecentDVDsCommand(), new ApiCallback<JSONObject>() {
+        rti.executeCall(new ApiCall(RTCommandFactory.getRecentDVDsCommand(), new ApiCallback<RTMovieListReceiver>() {
             @Override
-            public void onReceive(ApiReceiver<JSONObject> receiver) {
-                // TODO: make a entity builder object to automatically handle this
-                JSONObject newDVDs = receiver.getResponse();
-                try {
-                    JSONArray movieList = newDVDs.getJSONArray("movies");
-                    for (int i = 0; i < movieList.length(); i++) {
-                        JSONObject movie = movieList.getJSONObject(i);
-                        dvdList.add(movie.getString("title"));
-                    }
-                } catch (JSONException e) {
-                    e.printStackTrace();
+            public void onReceive(RTMovieListReceiver receiver) {
+                for (Movie m : receiver.getEntity()) {
+                    dvdList.add(m.toString());
                 }
             }
         }));

--- a/app/src/main/java/edu/gatech/buzzmovieselector/controller/BMSActivity.java
+++ b/app/src/main/java/edu/gatech/buzzmovieselector/controller/BMSActivity.java
@@ -20,15 +20,11 @@ import android.widget.ListView;
 import edu.gatech.buzzmovieselector.R;
 import edu.gatech.buzzmovieselector.biz.api.ApiCall;
 import edu.gatech.buzzmovieselector.biz.api.ApiCallback;
-import edu.gatech.buzzmovieselector.biz.api.ApiReceiver;
 import edu.gatech.buzzmovieselector.biz.api.impl.rt.RTInvoker;
 import edu.gatech.buzzmovieselector.biz.api.impl.rt.command.RTCommandFactory;
 import edu.gatech.buzzmovieselector.biz.api.impl.rt.receiver.RTMovieListReceiver;
 import edu.gatech.buzzmovieselector.entity.Movie;
 import edu.gatech.buzzmovieselector.service.SessionState;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 import java.util.ArrayList;
 

--- a/app/src/main/java/edu/gatech/buzzmovieselector/entity/Movie.java
+++ b/app/src/main/java/edu/gatech/buzzmovieselector/entity/Movie.java
@@ -56,10 +56,15 @@ public class Movie {
     public Movie() {
     }
 
-    public Movie(String title, int year) {
-        this.setYear(year);
-        this.setYear(year);
+    public Movie(String title, int year, double rating) {
+        this.title = title;
+        this.year = year;
+        this.rating = rating;
     }
 
+    @Override
+    public String toString() {
+        return "Movie: " + title + " Year: " + year + " Rate: " + rating;
+    }
 
 }

--- a/app/src/main/java/edu/gatech/buzzmovieselector/service/ApiNetwork.java
+++ b/app/src/main/java/edu/gatech/buzzmovieselector/service/ApiNetwork.java
@@ -19,6 +19,11 @@ public class ApiNetwork {
     private RequestQueue apiRequestQueue;
     private static Context apiContext;
 
+    /**
+     * Gets the ApiNetwork instance. This must be called before getInstance()
+     * @param context Android context to use
+     * @return the ApiNetwork object
+     */
     public static ApiNetwork getInstance(Context context) {
         if (ourInstance == null) {
             ourInstance = new ApiNetwork(context);
@@ -26,10 +31,18 @@ public class ApiNetwork {
         return ourInstance;
     }
 
-    // sort of unconventional but commands can't access the app context
+    /**
+     * Gets the ApiNetwork instance
+     * @return the ApiNetwork object
+     */
     public static ApiNetwork getInstance() {
         return ourInstance;
     }
+
+    /**
+     * Gives the Android Volley RequestQueue
+     * @return the singleton's RequestQueue instance
+     */
     public RequestQueue getApiRequestQueue() {
         if (apiRequestQueue == null) {
             apiRequestQueue = Volley.newRequestQueue(apiContext.getApplicationContext());
@@ -37,11 +50,21 @@ public class ApiNetwork {
         return apiRequestQueue;
     }
 
+    /**
+     * Private constructor for Singleton
+     * @param context Android application context
+     */
     private ApiNetwork(Context context) {
         apiContext = context;
         apiRequestQueue = getApiRequestQueue();
     }
 
+    /**
+     * Hits an Api expecting a JSON object
+     * @param url Api endpoint
+     * @param callback Callback to execute when finished
+     * @return ApiReceiver object with JSONObject response
+     */
     public ApiReceiver<JSONObject> apiJSON(String url, ApiCallback callback) {
         RequestFuture<JSONObject> jsonFuture = RequestFuture.newFuture();
         JsonObjectRequest jsonRequest = new JsonObjectRequest(Request.Method.GET, url, jsonFuture, jsonFuture);
@@ -50,6 +73,12 @@ public class ApiNetwork {
         return jsonReceiver;
     }
 
+    /**
+     * Hits an Api expecting a string
+     * @param url Api endpoint
+     * @param callback Callback to execute when finished
+     * @return ApiReceiver object with String response
+     */
     public ApiReceiver<String> apiString(String url, ApiCallback callback) {
         RequestFuture<String> stringFuture = RequestFuture.newFuture();
         StringRequest stringRequest = new StringRequest(Request.Method.GET, url, stringFuture, stringFuture);

--- a/app/src/main/java/edu/gatech/buzzmovieselector/service/ApiNetwork.java
+++ b/app/src/main/java/edu/gatech/buzzmovieselector/service/ApiNetwork.java
@@ -62,28 +62,24 @@ public class ApiNetwork {
     /**
      * Hits an Api expecting a JSON object
      * @param url Api endpoint
-     * @param callback Callback to execute when finished
-     * @return ApiReceiver object with JSONObject response
+     * @return RequestFuture object with JSONObject response
      */
-    public ApiReceiver<JSONObject> apiJSON(String url, ApiCallback callback) {
+    public RequestFuture<JSONObject> apiJSON(String url) {
         RequestFuture<JSONObject> jsonFuture = RequestFuture.newFuture();
         JsonObjectRequest jsonRequest = new JsonObjectRequest(Request.Method.GET, url, jsonFuture, jsonFuture);
-        ApiReceiver<JSONObject> jsonReceiver = new ApiReceiver<>(jsonFuture, callback);
         apiRequestQueue.add(jsonRequest);
-        return jsonReceiver;
+        return jsonFuture;
     }
 
     /**
      * Hits an Api expecting a string
      * @param url Api endpoint
-     * @param callback Callback to execute when finished
-     * @return ApiReceiver object with String response
+     * @return RequestFuture object with String response
      */
-    public ApiReceiver<String> apiString(String url, ApiCallback callback) {
+    public RequestFuture<String> apiString(String url) {
         RequestFuture<String> stringFuture = RequestFuture.newFuture();
         StringRequest stringRequest = new StringRequest(Request.Method.GET, url, stringFuture, stringFuture);
-        ApiReceiver<String> stringReceiver = new ApiReceiver<>(stringFuture, callback);
         apiRequestQueue.add(stringRequest);
-        return stringReceiver;
+        return stringFuture;
     }
 }


### PR DESCRIPTION
this should make the api framework easier to use. now ApiReceivers have getEntity() which will return the POJO type