### PR TITLE
Simple auto-lock feature

### DIFF
--- a/app/src/main/java/edu/gatech/buzzmovieselector/biz/impl/UserManager.java
+++ b/app/src/main/java/edu/gatech/buzzmovieselector/biz/impl/UserManager.java
@@ -63,8 +63,9 @@ public class UserManager implements AuthenticationFacade, UserManagementFacade {
     }
 
     public void updateUser(User user) {
-        if (user.getUsername().equals(SessionState.getInstance()
-                .getSessionUser().getUsername())) {
+        if (SessionState.getInstance().getSessionUser() != null
+                && user.getUsername().equals(
+                SessionState.getInstance().getSessionUser().getUsername())) {
             SessionState.getInstance().setSessionUser(user);
         }
         try {

--- a/app/src/main/java/edu/gatech/buzzmovieselector/controller/activity/LoginActivity.java
+++ b/app/src/main/java/edu/gatech/buzzmovieselector/controller/activity/LoginActivity.java
@@ -139,7 +139,7 @@ public class LoginActivity extends Activity {
             } else {
                 passwordText.setError("Invalid Password");
                 loginAttempts++;
-                if (loginAttempts == 3) {
+                if (loginAttempts >= 3) {
                     User attemptedUser = uf.findUserById(userName);
                     attemptedUser.setUserStatus(User.UserStatus.LOCKED);
                     uf.updateUser(attemptedUser);

--- a/app/src/main/java/edu/gatech/buzzmovieselector/controller/activity/LoginActivity.java
+++ b/app/src/main/java/edu/gatech/buzzmovieselector/controller/activity/LoginActivity.java
@@ -27,9 +27,12 @@ public class LoginActivity extends Activity {
     private AutoCompleteTextView userText;
     private EditText passwordText;
 
+    int loginAttempts;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        loginAttempts = 0;
         setContentView(R.layout.activity_login);
         userText = (AutoCompleteTextView) findViewById(R.id.username);
         passwordText = (EditText) findViewById(R.id.password);
@@ -135,6 +138,15 @@ public class LoginActivity extends Activity {
                 userText.setError("Invalid Username");
             } else {
                 passwordText.setError("Invalid Password");
+                loginAttempts++;
+                if (loginAttempts == 3) {
+                    User attemptedUser = uf.findUserById(userName);
+                    attemptedUser.setUserStatus(User.UserStatus.LOCKED);
+                    uf.updateUser(attemptedUser);
+                    Toast.makeText(LoginActivity.this, "Account locked: " +
+                            "too many attempts", Toast
+                            .LENGTH_SHORT).show();
+                }
             }
         }
     }


### PR DESCRIPTION
Right now it just counts how many "incorrect password" attempts you have. It does not reset the number of attempts when you change the username, but the counter only goes up when you have a valid username with an invalid password. 3 attempts locks the account.